### PR TITLE
Switch player teams to give skinned weapons correctly.

### DIFF
--- a/configs/deathmatch/deathmatch.ini
+++ b/configs/deathmatch/deathmatch.ini
@@ -237,5 +237,28 @@
 			"he"         "0"
 			"smoke"      "0"
 		}
+
+		"TeamData"
+		{
+			"weapon_ak47"			"T"
+			"weapon_m4a1"     		"CT"
+			"weapon_m4a1_silencer"	"CT"
+			"weapon_sg556"   		"T"
+			"weapon_aug"     		"CT"
+			"weapon_galilar" 		"T"
+			"weapon_famas"   		"CT"
+			"weapon_g3sg1"   		"T"
+			"weapon_scar20"  		"CT"
+			"weapon_sawedoff"		"T"
+			"weapon_mag7"    		"CT"
+			"weapon_mac10"   		"T"
+			"weapon_mp9"     		"CT"
+			"weapon_mp7"     		"CT"
+			"weapon_glock"			"T"
+			"weapon_usp_silencer"	"CT"
+			"weapon_fiveseven"		"CT"
+			"weapon_tec9"			"T"
+			"weapon_hkp2000"		"CT"
+		}
 	}
 }

--- a/scripting/deathmatch.sp
+++ b/scripting/deathmatch.sp
@@ -806,8 +806,9 @@ LoadConfig()
 	KvGetString(keyValues, "smoke", value, sizeof(value), "0");
 	SetConVarString(cvar_dm_nades_smoke, value);
 
-	if (KvJumpToKey(keyValues, "TeamData"))
-	{
+	KvGoBack(keyValues);
+
+	if (KvJumpToKey(keyValues, "TeamData") && KvGotoFirstSubKey(keyValues, false)) {
 		do {
 			KvGetSectionName(keyValues, key, sizeof(key));
 			KvGetString(keyValues, NULL_STRING, value, sizeof(value), "");
@@ -820,7 +821,7 @@ LoadConfig()
 			{
 				team = CS_TEAM_T;
 			}
-			weaponSkipMap.SetValue(value, team);
+			weaponSkipMap.SetValue(key, team);
 		} while (KvGotoNextKey(keyValues, false));
 		KvGoBack(keyValues);
 	}

--- a/scripting/deathmatch.sp
+++ b/scripting/deathmatch.sp
@@ -176,6 +176,7 @@ new Handle:secondaryWeaponsAvailable;
 new Handle:weaponMenuNames;
 new Handle:weaponLimits;
 new Handle:weaponCounts;
+StringMap weaponSkipMap;
 // Grenade/Misc options
 new bool:armorChest;
 new bool:armorFull;
@@ -240,6 +241,7 @@ public OnPluginStart()
 	// Create arrays to store available weapons loaded by config
 	primaryWeaponsAvailable = CreateArray(24);
 	secondaryWeaponsAvailable = CreateArray(10);
+	weaponSkipMap = new StringMap();
 	// Create trie to store menu names for weapons
 	BuildWeaponMenuNames();
 	// Create trie to store weapon limits and counts
@@ -803,6 +805,25 @@ LoadConfig()
 
 	KvGetString(keyValues, "smoke", value, sizeof(value), "0");
 	SetConVarString(cvar_dm_nades_smoke, value);
+
+	if (KvJumpToKey(keyValues, "TeamData"))
+	{
+		do {
+			KvGetSectionName(keyValues, key, sizeof(key));
+			KvGetString(keyValues, NULL_STRING, value, sizeof(value), "");
+			int team = 0;
+			if (StrEqual(value, "CT", false))
+			{
+				team = CS_TEAM_CT;
+			}
+			else if (StrEqual(value, "T", false))
+			{
+				team = CS_TEAM_T;
+			}
+			weaponSkipMap.SetValue(value, team);
+		} while (KvGotoNextKey(keyValues, false));
+		KvGoBack(keyValues);
+	}
 
 	CloseHandle(keyValues);
 }
@@ -3089,4 +3110,22 @@ RemoveRagdoll(client)
 		if (ragdoll != -1)
 			AcceptEntityInput(ragdoll, "Kill");
 	}
+}
+
+public int GetWeaponTeam(const char[] weapon)
+{
+	int team = 0;
+	weaponSkipMap.GetValue(weapon, team);
+	return team;
+}
+
+public void GiveSkinnedWeapon(int client, const char[] weapon)
+{
+    int playerTeam = GetEntProp(client, Prop_Data, "m_iTeamNum");
+    int weaponTeam = GetWeaponTeam(weapon);
+    if (weaponTeam > 0) {
+        SetEntProp(client, Prop_Data, "m_iTeamNum", weaponTeam);
+    }
+    GivePlayerItem(client, weapon);
+    SetEntProp(client, Prop_Data, "m_iTeamNum", playerTeam);
 }

--- a/scripting/deathmatch.sp
+++ b/scripting/deathmatch.sp
@@ -2200,11 +2200,11 @@ GiveSavedWeapons(client, bool:primary, bool:secondary)
 				new random = GetRandomInt(0, GetArraySize(primaryWeaponsAvailable) - 1);
 				decl String:randomWeapon[24];
 				GetArrayString(primaryWeaponsAvailable, random, randomWeapon, sizeof(randomWeapon));
-				GivePlayerItem(client, randomWeapon);
+				GiveSkinnedWeapon(client, randomWeapon);
 			}
 			else
 			{
-				GivePlayerItem(client, primaryWeapon[client]);
+				GiveSkinnedWeapon(client, primaryWeapon[client]);
 			}
 		}
 		if (secondary)
@@ -2223,11 +2223,11 @@ GiveSavedWeapons(client, bool:primary, bool:secondary)
 					new random = GetRandomInt(0, GetArraySize(secondaryWeaponsAvailable) - 1);
 					decl String:randomWeapon[24];
 					GetArrayString(secondaryWeaponsAvailable, random, randomWeapon, sizeof(randomWeapon));
-					GivePlayerItem(client, randomWeapon);
+					GiveSkinnedWeapon(client, randomWeapon);
 				}
 				else
 				{
-					GivePlayerItem(client, secondaryWeapon[client]);
+					GiveSkinnedWeapon(client, secondaryWeapon[client]);
 				}
 				GivePlayerItem(client, "weapon_knife");
 			}


### PR DESCRIPTION
As discussed in https://github.com/Maxximou5/csgo-deathmatch/issues/18

This keeps the "TeamData" section as optional in the config, and when doing weapon lookup defaults to "0", where it doesn't do any team switching based on this data. So if the section is missing, or a key is missing, the plugin operates the same as it did before.

Haven't tested it yet. Will try to do that later :)