### PR TITLE
Call State_Update() on OnMapStart()

### DIFF
--- a/scripting/deathmatch.sp
+++ b/scripting/deathmatch.sp
@@ -373,6 +373,8 @@ public void OnMapStart()
     }
     else if (!g_cvDM_spawn_default.BoolValue)
         State_SetSpawnPoints();
+        
+    State_Update();
 }
 
 public void OnClientPutInServer(int client)


### PR DESCRIPTION
I've been having some problems with a custom config loader that caused `dm_remove_ground_weapons` to not work correctly.

I had every config set to "yes" and yet `mp_death_drop_c4`, `mp_death_drop_defuser`, `mp_death_drop_grenade`,  `mp_death_drop_gun` and `mp_death_drop_taser` seems to remain the unchanged.

After some testing I figured everything was working correctly, since changing `dm_remove_ground_weapons` to different values, triggered the update function `State_SetNoDropWeapons`.

Then I discovered that the config was loaded OnPluginStart() and after someone joined the server, the `mp_death*` Convars got reset to their original value WITHOUT changing `dm_remove_ground_weapons`. Because of that, everytime I loaded a config where 
`dm_remove_ground_weapons` did not change, the `mp_death*` Convars would not get updated to the correct value, remaining at the same default (from server config?) value.

The fix was simply call State_Update() at the end of OnMapStart() so `mp_death*` would get updated without having to rely on some Convar changing.

I haven't trying to reproduce this problem on the normal config loader, but I guess it should happen too.